### PR TITLE
fix: deno and windows compatibility

### DIFF
--- a/lib/folder-diff.js
+++ b/lib/folder-diff.js
@@ -41,13 +41,15 @@ export async function neocitiesLocalDiff ({
   const ncFiles = new Set(neoCitiesFiltered.map(f => f.path)) // shape
 
   const localListingFiltered = localListing.filter(f => !f.stat.isDirectory()) // files only
+  localListingFiltered.forEach(v => { v.relname = forceUnixRelname(v.relname) })
+
   const localIndex = keyBy(localListingFiltered, 'relname')
-  const localFiles = new Set(localListingFiltered.map(f => forceUnixRelname(f.relname))) // shape
+  const localFiles = new Set(localListingFiltered.map(f => f.relname)) // shape
 
   const unsupportedFilesFiltered = localListingFiltered.filter(f =>
     !supportedFiletypes.has(path.extname(f.basename).toLowerCase())
   )
-  const unsupportedFilesSet = new Set(unsupportedFilesFiltered.map(f => forceUnixRelname(f.relname)))
+  const unsupportedFilesSet = new Set(unsupportedFilesFiltered.map(f => f.relname))
 
   /** @type {Set<string>} */
   const protectedSet = new Set()
@@ -133,7 +135,7 @@ async function sha1FromPath (p) {
   const rs = fs.createReadStream(p)
   const hash = crypto.createHash('sha1')
 
-  await pipeline(rs, hash)
+  await pipeline(rs, hash, { end: false })
 
   return hash.digest('hex')
 }


### PR DESCRIPTION
thanks for your work on this project!

this pr allows running async-neocities from deno and from windows, where it seems to have been broken for a while (months?)

on windows i would get an error like this (whether running through pnpm or deno):

```
Found siteName in config: (redacted)
API Key found for (redacted)
Error: Missing local file stats for (existing file)
    at neocitiesLocalDiff ((redacted)/node_modules/async-neocities/lib/folder-diff.js:74:23)
    at previewDeployToNeocities ((redacted)/node_modules/async-neocities/lib/api-endpoints.js:142:22)
```

the issue seems to be `localIndex` receiving windows-pathed relnames, while everything else uses unix-pathed relnames. so i moved the path shaping up to `localListingFiltered`

```diff
- await pipeline(rs, hash)
+ await pipeline(rs, hash, { end: false })
```

in node and deno, `pipeline()` closes streams by default, hash being a stream. in deno, [hash.digest()](https://docs.deno.com/api/node/crypto/~/Hash#method_digest_0) cannot operate on a "closed" hash. this broke running async-neocities from deno

i made these patches locally a few months ago, i am upstreaming them now. ran this against my own neocities (both via binary and via a simple deploy script, and both from windows and linux), and it worked fine for me