### PR TITLE
Update supported file types

### DIFF
--- a/lib/supported-filetypes.js
+++ b/lib/supported-filetypes.js
@@ -18,6 +18,7 @@ export const supportedFiletypes = new Set([
   '.geojson',
   '.gif',
   '.glb',
+  '.glsl',
   '.gltf',
   '.gpg',
   '.htm',
@@ -27,6 +28,7 @@ export const supportedFiletypes = new Set([
   '.jpg',
   '.js',
   '.json',
+  '.jxl',
   '.key',
   '.kml',
   '.knowl',
@@ -54,6 +56,7 @@ export const supportedFiletypes = new Set([
   '.rss',
   '.sass',
   '.scss',
+  '.sf2',
   '.svg',
   '.text',
   '.toml',
@@ -68,6 +71,8 @@ export const supportedFiletypes = new Set([
   '.woff2',
   '.xcf',
   '.xml',
+  '.xsl',
+  '.xslt',
   '.yaml',
   '.yml'
 ])


### PR DESCRIPTION
Neocities now supports glsl, jxl, sf2, xsl and xslt as well.

The deploy-to-neocities action wasn't uploading my `xsl` file, so I tracked it to async-neocities.

Thanks for the two projects!